### PR TITLE
Support filters in if, elsif, and unless

### DIFF
--- a/test/solid/tags/if_tag_test.exs
+++ b/test/solid/tags/if_tag_test.exs
@@ -413,4 +413,31 @@ defmodule Solid.Tags.IfTagTest do
       assert {[%Solid.Text{text: " elsif3 "}], ^context} = Renderable.render(tag, context, [])
     end
   end
+
+  test "if with filter in unary condition" do
+    template = ~s<{% if items | size %} has items {% endif %}>
+    context = %Solid.Context{vars: %{"items" => [1, 2, 3]}}
+
+    {:ok, tag, _rest} = parse(template)
+
+    assert {[%Solid.Text{text: " has items "}], _} = Renderable.render(tag, context, [])
+  end
+
+  test "if with filter in binary condition" do
+    template = ~s<{% if name | upcase == "JOHN" %} match {% endif %}>
+    context = %Solid.Context{vars: %{"name" => "john"}}
+
+    {:ok, tag, _rest} = parse(template)
+
+    assert {[%Solid.Text{text: " match "}], _} = Renderable.render(tag, context, [])
+  end
+
+  test "unless with filter in condition" do
+    template = ~s({% unless items | size > 0 %} empty {% endunless %})
+    context = %Solid.Context{vars: %{"items" => []}}
+
+    {:ok, tag, _rest} = parse(template)
+
+    assert {[%Solid.Text{text: " empty "}], _} = Renderable.render(tag, context, [])
+  end
 end


### PR DESCRIPTION
Filters in `{% if %}`, `{% elsif %}`, and `{% unless %}` tags stopped working in 1.x. The `BinaryCondition` and `UnaryCondition` structs already had filter fields (`left_argument_filters`, `right_argument_filters`, `argument_filters`) but they were never populated during parsing or used during evaluation.

This updates `ConditionExpression.parse/1` to use `Argument.parse_with_filters/1` instead of `Argument.parse/1`, and passes the captured filters through to `Argument.get/4` during evaluation.

Enables templates like:

`{% if items | size > 0 %}...{% endif %}`
`{% if name | upcase == "JOHN" %}...{% endif %}`
`{% unless items | size > 0 %}...{% endunless %}`