### PR TITLE
fix(PLA-2268): correctly parse 'contains' in the lexer

### DIFF
--- a/lib/solid/lexer.ex
+++ b/lib/solid/lexer.ex
@@ -265,11 +265,6 @@ defmodule Solid.Lexer do
         acc = [{:comparison, build_loc(line, column), String.to_atom(operator)} | acc]
         tokenize(rest, line, column + 1, acc)
 
-      # "contains" keyword
-      <<"contains", rest::binary>> ->
-        acc = [{:comparison, build_loc(line, column), :contains} | acc]
-        tokenize(rest, line, column + 8, acc)
-
       # Single or double quotes
       <<quote_char::binary-size(1), _rest::binary>> when quote_char in ["'", "\""] ->
         with {:string, string_value, quotes, rest, end_line, end_column} <-
@@ -301,12 +296,18 @@ defmodule Solid.Lexer do
             tokenize(rest, end_line, end_column, acc)
         end
 
-      # Identifiers
+      # Identifiers and "contains" keyword (checked after full identifier is parsed)
       <<letter::binary-size(1), rest::binary>> when letter in @letters ->
         {:identifier, identifier, rest, end_line, end_column} =
           identifier(rest, line, column + 1, [letter])
 
-        acc = [{:identifier, build_loc(line, column), identifier} | acc]
+        token =
+          case identifier do
+            "contains" -> {:comparison, build_loc(line, column), :contains}
+            _ -> {:identifier, build_loc(line, column), identifier}
+          end
+
+        acc = [token | acc]
         tokenize(rest, end_line, end_column, acc)
 
       # Empty string (end of input)
@@ -356,11 +357,6 @@ defmodule Solid.Lexer do
         acc = [{:comparison, build_loc(line, column), String.to_atom(operator)} | acc]
         tokenize_for_liquid_tag(rest, line, column + 1, acc)
 
-      # "contains" keyword
-      <<"contains", rest::binary>> ->
-        acc = [{:comparison, build_loc(line, column), :contains} | acc]
-        tokenize_for_liquid_tag(rest, line, column + 8, acc)
-
       # Single or double quotes
       <<quote_char::binary-size(1), _rest::binary>> when quote_char in ["'", "\""] ->
         with {:string, string_value, quotes, rest, end_line, end_column} <-
@@ -392,12 +388,18 @@ defmodule Solid.Lexer do
             tokenize_for_liquid_tag(rest, end_line, end_column, acc)
         end
 
-      # Identifiers
+      # Identifiers and "contains" keyword (checked after full identifier is parsed)
       <<letter::binary-size(1), rest::binary>> when letter in @letters ->
         {:identifier, identifier, rest, end_line, end_column} =
           identifier(rest, line, column + 1, [letter])
 
-        acc = [{:identifier, build_loc(line, column), identifier} | acc]
+        token =
+          case identifier do
+            "contains" -> {:comparison, build_loc(line, column), :contains}
+            _ -> {:identifier, build_loc(line, column), identifier}
+          end
+
+        acc = [token | acc]
         tokenize_for_liquid_tag(rest, end_line, end_column, acc)
 
       # Empty string (end of input)

--- a/test/solid/lexer_test.exs
+++ b/test/solid/lexer_test.exs
@@ -416,6 +416,34 @@ defmodule Solid.LexerTest do
              }
     end
 
+    test "identifier starting with 'contains' is not split into operator + remainder" do
+      context = "{{containsItems}}" |> build_context
+
+      assert Lexer.tokenize_object(context) == {
+               :ok,
+               [
+                 {:identifier, %{column: 3, line: 1}, "containsItems"},
+                 {:end, %{column: 16, line: 1}}
+               ],
+               %ParserContext{rest: "", line: 1, column: 18, mode: :normal}
+             }
+    end
+
+    test "identifier starting with 'contains' alongside the 'contains' operator" do
+      context = "{{containsItems contains 'foo'}}" |> build_context
+
+      assert Lexer.tokenize_object(context) == {
+               :ok,
+               [
+                 {:identifier, %{column: 3, line: 1}, "containsItems"},
+                 {:comparison, %{column: 17, line: 1}, :contains},
+                 {:string, %{column: 26, line: 1}, "foo", ?'},
+                 {:end, %{column: 31, line: 1}}
+               ],
+               %ParserContext{rest: "", line: 1, column: 33, mode: :normal}
+             }
+    end
+
     test "specials" do
       context = "{{. | [ ] : , }}" |> build_context
 

--- a/test/solid/tags/if_tag_test.exs
+++ b/test/solid/tags/if_tag_test.exs
@@ -440,4 +440,16 @@ defmodule Solid.Tags.IfTagTest do
 
     assert {[%Solid.Text{text: " empty "}], _} = Renderable.render(tag, context, [])
   end
+
+  test "variable name starting with 'contains' is not mistaken for the contains operator" do
+    template = ~s<{% if containsItems == false %} yes {% else %} no {% endif %}>
+
+    {:ok, tag, _rest} = parse(template)
+
+    context_false = %Solid.Context{vars: %{"containsItems" => false}}
+    assert {[%Solid.Text{text: " yes "}], _} = Renderable.render(tag, context_false, [])
+
+    context_true = %Solid.Context{vars: %{"containsItems" => true}}
+    assert {[%Solid.Text{text: " no "}], _} = Renderable.render(tag, context_true, [])
+  end
 end


### PR DESCRIPTION
### Description
A template with a variable that starts with "contains" is incorrectly being parsed as a `contains` keyword in the Solid lexer. This fixes it by not doing a greedy pattern match on the "contains" string and instead pushes it down to the catchall.

**Example**:

Trying to parse this results in a `TemplateError`
```
{% assign containsItems = false %}
```
